### PR TITLE
Use anon s3 access (for public data)

### DIFF
--- a/2-dataframes-at-scale.ipynb
+++ b/2-dataframes-at-scale.ipynb
@@ -73,6 +73,7 @@
     "\n",
     "df = dd.read_parquet(\n",
     "    \"s3://coiled-datasets/dask-book/nyc-tlc/2009\"\n",
+    "    storage_options={\"anon\":True},\n",
     ")\n",
     "df.head()"
    ]


### PR DESCRIPTION
If we don't explicitly use this kwarg, then boto will try to hit IMDS endpoint and fail and give up.